### PR TITLE
Ruby support: EOL 2.4.x

### DIFF
--- a/docker-rvm-support/Dockerfile
+++ b/docker-rvm-support/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 # gem update to ensure railties binstubs are correct for Rails 6
-RUN  bash --login -c 'gem update'
+RUN echo 'gem: --no-document' > /root/.gemrc && bash --login -c 'gem update'
 
 # set the time zone
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker-rvm-support/Dockerfile
+++ b/docker-rvm-support/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # make sure the base is upgraded, so downstream images don't have to do it
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
+# gem update to ensure railties binstubs are correct for Rails 6
+RUN  bash --login -c 'gem update'
 
 # set the time zone
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker-rvm-support/Dockerfile
+++ b/docker-rvm-support/Dockerfile
@@ -1,5 +1,5 @@
 ARG RVM_RUBY_VERSIONS="2.6.6 2.7.1 2.5.8 2.4.10"
-FROM kingdonb/docker-rvm:20200620
+FROM kingdonb/docker-rvm:20200706
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"
 

--- a/docker-rvm-support/Dockerfile
+++ b/docker-rvm-support/Dockerfile
@@ -1,4 +1,4 @@
-ARG RVM_RUBY_VERSIONS="2.6.6 2.7.1 2.5.8 2.4.10"
+ARG RVM_RUBY_VERSIONS="2.6.6 2.7.1 2.5.8"
 FROM kingdonb/docker-rvm:20200706
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"

--- a/docker-rvm-support/Dockerfile.oci8
+++ b/docker-rvm-support/Dockerfile.oci8
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 # gem update to ensure railties binstubs are correct for Rails 6
-RUN  bash --login -c 'gem update'
+RUN echo 'gem: --no-document' > /root/.gemrc && bash --login -c 'gem update'
 
 # set the time zone
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker-rvm-support/Dockerfile.oci8
+++ b/docker-rvm-support/Dockerfile.oci8
@@ -9,6 +9,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # make sure the base is upgraded, so downstream images don't have to do it
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
+# gem update to ensure railties binstubs are correct for Rails 6
+RUN  bash --login -c 'gem update'
 
 # set the time zone
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker-rvm-support/Dockerfile.oci8
+++ b/docker-rvm-support/Dockerfile.oci8
@@ -1,5 +1,5 @@
 ARG RVM_RUBY_VERSIONS="2.6.6 2.7.1 2.5.8 2.4.10"
-FROM kingdonb/docker-rvm:20200620
+FROM kingdonb/docker-rvm:20200706
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"
 

--- a/docker-rvm-support/Dockerfile.oci8
+++ b/docker-rvm-support/Dockerfile.oci8
@@ -1,4 +1,4 @@
-ARG RVM_RUBY_VERSIONS="2.6.6 2.7.1 2.5.8 2.4.10"
+ARG RVM_RUBY_VERSIONS="2.6.6 2.7.1 2.5.8"
 FROM kingdonb/docker-rvm:20200706
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"

--- a/docker-rvm-support/Dockerfile.unsupported
+++ b/docker-rvm-support/Dockerfile.unsupported
@@ -1,5 +1,5 @@
 ARG RVM_RUBY_VERSIONS="2.3.8 2.2.10 2.1.10 2.0.0-p648"
-FROM kingdonb/docker-rvm:20200620
+FROM kingdonb/docker-rvm:20200706
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"
 

--- a/docker-rvm-support/Dockerfile.unsupported
+++ b/docker-rvm-support/Dockerfile.unsupported
@@ -1,4 +1,4 @@
-ARG RVM_RUBY_VERSIONS="2.3.8 2.2.10 2.1.10 2.0.0-p648"
+ARG RVM_RUBY_VERSIONS="2.4.10 2.3.8 2.2.10 2.1.10 2.0.0-p648"
 FROM kingdonb/docker-rvm:20200706
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"

--- a/docker-rvm-support/Dockerfile.unsupported.oci8
+++ b/docker-rvm-support/Dockerfile.unsupported.oci8
@@ -1,5 +1,5 @@
 ARG RVM_RUBY_VERSIONS="2.3.8 2.2.10 2.1.10 2.0.0-p648"
-FROM kingdonb/docker-rvm:20200620
+FROM kingdonb/docker-rvm:20200706
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"
 

--- a/docker-rvm-support/Dockerfile.unsupported.oci8
+++ b/docker-rvm-support/Dockerfile.unsupported.oci8
@@ -1,4 +1,4 @@
-ARG RVM_RUBY_VERSIONS="2.3.8 2.2.10 2.1.10 2.0.0-p648"
+ARG RVM_RUBY_VERSIONS="2.4.10 2.3.8 2.2.10 2.1.10 2.0.0-p648"
 FROM kingdonb/docker-rvm:20200706
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"


### PR DESCRIPTION
The 2.4.x Ruby tree has reached EOL some time ago, so we remove it here from the docker-rvm-support images that are not flagged with an "unsupported" label, and conversely add 2.4.10 into the images with an "unsupported" status label.

"`gem update`" with Ruby 2.5+ produces some required changes in `/usr/local/` binstubs (required by newer versions of Rails such as Rails 6.1pre) that are placed automatically by rvm installer. Since we don't need the backwards compatibility here in the Supported image we can resolve it here with `gem update`, also now adding a more recent bundler version 2.x.

We add the `--no-document` flag first in `/root/.gemrc` because these system-wide gems will otherwise take significant extra time during each build regenerating documentation in two different formats, which we will not likely use in any format.

Finally, since some time has passed, the upstream docker-rvm retag is rolled to today's date `20200706` ensuring images have the most current packages installed before any part of RVM placement of Ruby versions into the images has begun.