### PR TITLE
Buildkit Test (docker-rvm-test/)

### DIFF
--- a/docker-rvm-test/Gemfile
+++ b/docker-rvm-test/Gemfile
@@ -27,6 +27,9 @@ gem 'lograge'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'factory_bot_rails'
+  # dotenv gem for secrets in .env auto-loading
+  gem 'dotenv'
 end
 
 group :development do

--- a/docker-rvm-test/Gemfile.lock
+++ b/docker-rvm-test/Gemfile.lock
@@ -74,8 +74,14 @@ GEM
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     debug_inspector (0.0.3)
+    dotenv (2.7.6)
     e2mmap (0.1.0)
     erubi (1.9.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -225,6 +231,8 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.4.2)
   byebug
+  dotenv
+  factory_bot_rails
   jbuilder (~> 2.7)
   listen (~> 3.2)
   lograge

--- a/docker-rvm-test/Makefile
+++ b/docker-rvm-test/Makefile
@@ -1,8 +1,10 @@
-.PHONY: test tag-latest push-tag push-latest push buildkit
+.PHONY: test tag-latest push-tag push-latest push buildkit all old-all
 
 ISO_DATE_TAG := $(shell date +%Y%m%d)
 
-all: test push
+all: buildkit
+
+old-all: test push
 
 test:
 	docker build --no-cache --target test-base -t kingdonb/docker-rvm:$(ISO_DATE_TAG)-test-base .


### PR DESCRIPTION
On any given build host, "make buildkit" should be faster the second time as it should always reuse the bundle cache, in case Dockerfile, Gemfile or Gemfile.lock is changed

The gem cache is reused so only the gems that changed should need to rebuild. This saves a great deal of time building Ruby app images when using bundler on a Gemfile!