### PR TITLE
Test base image swap

### DIFF
--- a/docker-rvm-test/Dockerfile
+++ b/docker-rvm-test/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 ARG RVM_RUBY_VERSIONS="2.7.1"
-FROM kingdonb/docker-rvm:20200829 as test-base
+FROM kingdonb/docker-rvm-support:20200829 as test-base
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"
 

--- a/docker-rvm-test/Dockerfile
+++ b/docker-rvm-test/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 ARG RVM_RUBY_VERSIONS="2.7.1"
-FROM kingdonb/docker-rvm:20200815 as test-base
+FROM kingdonb/docker-rvm:20200829 as test-base
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"
 
@@ -41,6 +41,7 @@ RUN chown ${RVM_USER} ${APPDIR}
 #     chmod 640 /etc/container_environment.sh /etc/container_environment.json ; \
 #     ln -s /etc/container_environment.sh /etc/profile.d/
 USER ${RVM_USER}
+RUN  echo 'gem: --no-document' > /home/${RVM_USER}/.gemrc && rvm ${RUBY} do gem update --system
 RUN  bash --login -c 'curl -o- -L https://yarnpkg.com/install.sh | bash'
 # USER root
 # ENTRYPOINT ["/sbin/my_init", "--"]

--- a/docker-rvm-test/Dockerfile
+++ b/docker-rvm-test/Dockerfile
@@ -4,6 +4,7 @@ FROM kingdonb/docker-rvm-support:20200829 as test-base
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"
 
+USER root
 # install manpages and a little vim because I might need them
 RUN apt-get update && apt-get install -y --no-install-recommends \
   manpages vim-tiny runit python3 && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/docker-rvm-test/Dockerfile
+++ b/docker-rvm-test/Dockerfile
@@ -16,13 +16,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 USER ${RVM_USER}
+ENV RUBY=2.7.1
 RUN  echo 'gem: --no-document' > /home/${RVM_USER}/.gemrc && rvm ${RUBY} do gem update --system
 # USER root
 # ENTRYPOINT ["/sbin/my_init", "--"]
 
 # # Example downstream Dockerfile:
 FROM test-base as test
-ENV RUBY=2.7.1
 #
 # # include the ruby-version and Gemfile for bundle install
 COPY --chown=rvm Gemfile Gemfile.lock .ruby-version ${APPDIR}/

--- a/docker-rvm-test/Dockerfile
+++ b/docker-rvm-test/Dockerfile
@@ -7,19 +7,18 @@ ENV APPDIR="/home/${RVM_USER}/app"
 USER root
 # install manpages and a little vim because I might need them
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  manpages vim-tiny runit python3 && apt-get clean && rm -rf /var/lib/apt/lists/*
-# make sure the base is upgraded, so downstream images don't have to do it
-RUN apt-get update && apt-get upgrade -y --no-install-recommends \
+  manpages vim-tiny runit python3 \
+  build-essential nodejs \
+  tzdata libpq-dev \
+  && apt-get upgrade -y --no-install-recommends \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+  && bash --login -c 'curl -o- -L https://yarnpkg.com/install.sh | bash' \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 # gem update to ensure railties binstubs are correct for Rails 6
 RUN echo 'gem: --no-document' > /root/.gemrc && bash --login -c 'gem update'
 
 # set the time zone
 ENV DEBIAN_FRONTEND=noninteractive
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  build-essential nodejs \
-  tzdata libpq-dev && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN echo "America/New_York" > /etc/timezone
 RUN unlink /etc/localtime
 RUN dpkg-reconfigure -f noninteractive tzdata
@@ -43,7 +42,6 @@ RUN chown ${RVM_USER} ${APPDIR}
 #     ln -s /etc/container_environment.sh /etc/profile.d/
 USER ${RVM_USER}
 RUN  echo 'gem: --no-document' > /home/${RVM_USER}/.gemrc && rvm ${RUBY} do gem update --system
-RUN  bash --login -c 'curl -o- -L https://yarnpkg.com/install.sh | bash'
 # USER root
 # ENTRYPOINT ["/sbin/my_init", "--"]
 

--- a/docker-rvm-test/Dockerfile
+++ b/docker-rvm-test/Dockerfile
@@ -14,32 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && bash --login -c 'curl -o- -L https://yarnpkg.com/install.sh | bash' \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
-# gem update to ensure railties binstubs are correct for Rails 6
-RUN echo 'gem: --no-document' > /root/.gemrc && bash --login -c 'gem update'
 
-# set the time zone
-ENV DEBIAN_FRONTEND=noninteractive
-RUN echo "America/New_York" > /etc/timezone
-RUN unlink /etc/localtime
-RUN dpkg-reconfigure -f noninteractive tzdata
-
-# put an app dir in place and ensure the user can manage it without escalation
-RUN mkdir ${APPDIR}
-WORKDIR ${APPDIR}
-
-RUN chown ${RVM_USER} ${APPDIR}
-# ADD my_init /sbin/my_init
-# RUN mkdir -p /etc/my_init.d \
-#   mkdir -p /etc/my_init.pre_shutdown.d ; \
-#   mkdir -p /etc/my_init.post_shutdown.d ; \
-#   mkdir -p /etc/container_environment ; \
-#   touch /etc/container_environment.sh ; \
-#   touch /etc/container_environment.json ; \
-#   chmod 700 /etc/container_environment ; \
-#     groupadd -g 8377 docker_env ; \
-#     chown :docker_env /etc/container_environment.sh /etc/container_environment.json ; \
-#     chmod 640 /etc/container_environment.sh /etc/container_environment.json ; \
-#     ln -s /etc/container_environment.sh /etc/profile.d/
 USER ${RVM_USER}
 RUN  echo 'gem: --no-document' > /home/${RVM_USER}/.gemrc && rvm ${RUBY} do gem update --system
 # USER root


### PR DESCRIPTION
Test upgrading to a new base image (upstream `FROM` image)

We offload most of the work that changes least frequently to a base image `docker-rvm-support`

Because of the buildkit bundle/gem cache volume mounted in `bundle install` step, the bundle install completes very rapidly even though the traditional layer-based image cache is now invalid!

```
[+] Building 17.1s (17/17) FINISHED
```

NONE of these _layers_ are from cache. The build still completes in 17s! 👍 💯 🥇 