### PR TITLE
Update supported image for 2022 Ruby versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ docker-rvm-support/ora-support/instantclient-sqlplus-linux.x64-12.2.0.1.0.zip
 docker-rvm-support/ora-support/instantclient-basiclite-linux.x64-19.8.0.0.0dbru.zip
 docker-rvm-support/ora-support/instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip
 docker-rvm-support/ora-support/instantclient-sqlplus-linux.x64-19.8.0.0.0dbru.zip
+docker-rvm-support/ora-support/instantclient-basiclite-linux.x64-21.6.0.0.0dbru.zip
+docker-rvm-support/ora-support/instantclient-sdk-linux.x64-21.6.0.0.0dbru.zip
+docker-rvm-support/ora-support/instantclient-sqlplus-linux.x64-21.6.0.0.0dbru.zip

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,14 @@ push-legacy: build-legacy
 	docker push kingdonb/docker-rvm:$(ISO_DATE_TAG)-legacy
 
 build:
-	docker build --no-cache -t kingdonb/docker-rvm:$(ISO_DATE_TAG) .
+	docker build --push --no-cache -t kingdonb/docker-rvm:$(ISO_DATE_TAG) .
 
 check:
 	docker pull yebyen/docker-rvm:test
 	docker build -f docker-rvm-test/Dockerfile.check -t yebyen/docker-rvm:check .
 
 tag-latest: build
+	docker pull kingdonb/docker-rvm:$(ISO_DATE_TAG)
 	docker tag kingdonb/docker-rvm:$(ISO_DATE_TAG) kingdonb/docker-rvm:latest
 
 push-tag: build

--- a/docker-rvm-ruby3/Dockerfile
+++ b/docker-rvm-ruby3/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:experimental
-FROM kingdonb/docker-rvm-support:20210223-ruby3
+FROM kingdonb/docker-rvm-support:20220620-ruby3
 LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
 ENV APPDIR="/home/${RVM_USER}/app"
 
@@ -7,12 +7,17 @@ ENV APPDIR="/home/${RVM_USER}/app"
 ADD Gemfile Gemfile.lock ${APPDIR}/
 ADD jenkins/bundle-install-all-versions.sh ${APPDIR}/jenkins/
 
-ENV RUBY_VERSIONS="3.0.0"
+ENV RUBY_VERSIONS="3.0.4 3.1.2"
 
-RUN --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-3.0.0/lib/ruby/gems/3.0.0 \
+RUN --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-3.0.4/lib/ruby/gems/3.0.0 \
+    --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/gems/3.1.0 \
     --mount=type=ssh,uid=999,gid=1000 \
     ${APPDIR}/jenkins/bundle-install-all-versions.sh
-RUN  rm -r /usr/local/rvm/rubies/ruby-3.0.0/lib/ruby/gems/3.0.0/* \
-  && cp -r /tmp/cache/3.0/* /usr/local/rvm/rubies/ruby-3.0.0/lib/ruby/gems/3.0.0/ \
+RUN  rm -r /usr/local/rvm/rubies/ruby-3.0.4/lib/ruby/gems/3.0.0/* \
+  && cp -r /tmp/cache/3.0/* /usr/local/rvm/rubies/ruby-3.0.4/lib/ruby/gems/3.0.0/ \
   && rm -r /tmp/cache # \
-#  && rm -r /usr/local/rvm/rubies/ruby-3.0.0/lib/ruby/gems/3.0.0/bundler/gems/rails-a1d35aecc6e2
+#  && rm -r /usr/local/rvm/rubies/ruby-3.0.4/lib/ruby/gems/3.0.0/bundler/gems/rails-a1d35aecc6e2
+RUN  rm -r /usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/gems/3.1.0/* \
+  && cp -r /tmp/cache/3.1/* /usr/local/rvm/rubies/ruby-3.1.2/lib/ruby/gems/3.1.0/ \
+  && rm -r /tmp/cache # \
+#  && rm -r /usr/local/rvm/rubies/ruby-3.0.4/lib/ruby/gems/3.0.0/bundler/gems/rails-a1d35aecc6e2

--- a/docker-rvm-ruby3/Makefile
+++ b/docker-rvm-ruby3/Makefile
@@ -7,9 +7,10 @@ all: build build-release push-latest push-tag
 push-release: push-tag push-latest
 
 build:
-	docker image build --squash -t kingdonb/rvm-ruby3:$(GIT_SHA_TAG) .
+	docker image build --push --squash -t kingdonb/rvm-ruby3:$(GIT_SHA_TAG) .
 
 build-release:
+	docker pull kingdonb/rvm-ruby3:$(GIT_SHA_TAG)
 	docker tag kingdonb/rvm-ruby3:$(GIT_SHA_TAG) kingdonb/rvm-ruby3:latest
 
 push-tag:

--- a/docker-rvm-support/Dockerfile
+++ b/docker-rvm-support/Dockerfile
@@ -1,6 +1,6 @@
-ARG RVM_RUBY_VERSIONS="2.7.4 2.6.8 3.0.2"
-FROM kingdonb/docker-rvm:20210819
-LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
+ARG RVM_RUBY_VERSIONS="2.7.6 2.6.10 3.0.4"
+FROM kingdonb/docker-rvm:20220620
+LABEL maintainer="Kingdon Barrett <kingdon@weave.works>"
 ENV APPDIR="/home/${RVM_USER}/app"
 
 # install manpages and a little vim because I might need them

--- a/docker-rvm-support/Dockerfile.oci8
+++ b/docker-rvm-support/Dockerfile.oci8
@@ -1,6 +1,6 @@
-ARG RVM_RUBY_VERSIONS="2.7.4 2.6.8 3.0.2"
-FROM kingdonb/docker-rvm:20210819
-LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
+ARG RVM_RUBY_VERSIONS="2.7.6 2.6.10 3.0.4"
+FROM kingdonb/docker-rvm:20220620
+LABEL maintainer="Kingdon Barrett <kingdon@weave.works>"
 ENV APPDIR="/home/${RVM_USER}/app"
 
 # install manpages and a little vim because I might need them
@@ -22,18 +22,18 @@ RUN echo "America/New_York" > /etc/timezone
 RUN unlink /etc/localtime
 RUN dpkg-reconfigure -f noninteractive tzdata
 
-COPY ora-support/*-19.8.*.zip /
+COPY ora-support/*-21.6.*.zip /
 COPY ora-support/tns /etc/oracle
 RUN set -ex \
   && mkdir -p /opt/oracle \
   && cd /opt/oracle \
-  && unzip /instantclient-basiclite-linux.x64-19.8.0.0.0dbru.zip \
-  && unzip /instantclient-sdk-linux.x64-19.8.0.0.0dbru.zip \
-  && unzip /instantclient-sqlplus-linux.x64-19.8.0.0.0dbru.zip \
-  && cd /opt/oracle/instantclient_19_8 # \
+  && unzip /instantclient-basiclite-linux.x64-21.6.0.0.0dbru.zip \
+  && unzip /instantclient-sdk-linux.x64-21.6.0.0.0dbru.zip \
+  && unzip /instantclient-sqlplus-linux.x64-21.6.0.0.0dbru.zip \
+  && cd /opt/oracle/instantclient_21_6 # \
   # && ln -s libclntsh.so.19.1 libclntsh.so
 
-ENV LD_LIBRARY_PATH /opt/oracle/instantclient_19_8
+ENV LD_LIBRARY_PATH /opt/oracle/instantclient_21_6
 ENV TNS_ADMIN /etc/oracle
 # ENV HOME "/home/${RVM_USER}"
 

--- a/docker-rvm-support/Dockerfile.ruby3
+++ b/docker-rvm-support/Dockerfile.ruby3
@@ -1,6 +1,6 @@
-ARG RVM_RUBY_VERSIONS="3.0.2"
-FROM kingdonb/docker-rvm:20210819
-LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
+ARG RVM_RUBY_VERSIONS="3.0.4 3.1.2"
+FROM kingdonb/docker-rvm:20220620
+LABEL maintainer="Kingdon Barrett <kingdon@weave.works>"
 ENV APPDIR="/home/${RVM_USER}/app"
 
 # install manpages and a little vim because I might need them

--- a/docker-rvm-support/Makefile
+++ b/docker-rvm-support/Makefile
@@ -27,19 +27,20 @@ push-release: push-tag push-latest
 push-unsupported-release: push-tag-unsupported push-latest-unsupported
 
 build-push-ruby3:
-	docker build -f Dockerfile.ruby3 -t kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-ruby3 .
+	docker build --push -f Dockerfile.ruby3 -t kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-ruby3 .
+	docker pull kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-ruby3
 	docker tag kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-ruby3 kingdonb/docker-rvm-support:latest-ruby3
 	docker push kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-ruby3
 	docker push kingdonb/docker-rvm-support:latest-ruby3
 
 build:
-	docker build -t kingdonb/docker-rvm-support:latest .
+	docker build --push -t kingdonb/docker-rvm-support:latest .
 
 build-release:
-	docker build -t kingdonb/docker-rvm-support:$(ISO_DATE_TAG) .
+	docker build --push -t kingdonb/docker-rvm-support:$(ISO_DATE_TAG) .
 
 build-release-oci8:
-	docker build -f Dockerfile.oci8 -t kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-oci8 .
+	docker build --push -f Dockerfile.oci8 -t kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-oci8 .
 
 build-unsupported:
 	docker build -f Dockerfile.unsupported -t kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-unsupported .
@@ -55,6 +56,8 @@ push-oci8-unsupported:
 	docker push kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-oci8-unsupported
 
 tag-latest: build
+	docker pull kingdonb/docker-rvm-support:$(ISO_DATE_TAG)
+	docker pull kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-oci8
 	docker tag kingdonb/docker-rvm-support:$(ISO_DATE_TAG) kingdonb/docker-rvm-support:latest
 	docker tag kingdonb/docker-rvm-support:$(ISO_DATE_TAG)-oci8 kingdonb/docker-rvm-support:latest-oci8
 

--- a/docker-rvm-supported/Dockerfile
+++ b/docker-rvm-supported/Dockerfile
@@ -1,24 +1,24 @@
 # syntax = docker/dockerfile:experimental
-FROM kingdonb/docker-rvm-support:20210819
-LABEL maintainer="Kingdon Barrett <kingdon.b@nd.edu>"
+FROM kingdonb/docker-rvm-support:20220620
+LABEL maintainer="Kingdon Barrett <kingdon@weave.works>"
 ENV APPDIR="/home/${RVM_USER}/app"
 
 # include the ruby-version and Gemfile for bundle install
 ADD Gemfile Gemfile.lock ${APPDIR}/
 ADD jenkins/bundle-install-all-versions.sh ${APPDIR}/jenkins/
 
-ENV RUBY_VERSIONS="2.7.4 2.6.8 3.0.2"
+ENV RUBY_VERSIONS="2.7.6 2.6.10 3.0.4"
 
 ENV LD_LIBRARY_PATH /opt/oracle/instantclient_19_8
 ENV TNS_ADMIN /etc/oracle
-RUN --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0 \
-    --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-2.7.4/lib/ruby/gems/2.7.0 \
-    --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-3.0.2/lib/ruby/gems/3.0.0 \
+RUN --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-2.6.10/lib/ruby/gems/2.6.0 \
+    --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-2.7.6/lib/ruby/gems/2.7.0 \
+    --mount=type=cache,uid=999,gid=1000,target=/usr/local/rvm/rubies/ruby-3.0.4/lib/ruby/gems/3.0.0 \
     --mount=type=ssh,uid=999,gid=1000 \
     ${APPDIR}/jenkins/bundle-install-all-versions.sh
-RUN  rm -r /usr/local/rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/* \
-  && cp -r /tmp/cache/2.6/* /usr/local/rvm/rubies/ruby-2.6.8/lib/ruby/gems/2.6.0/ \
-  && rm -r /usr/local/rvm/rubies/ruby-2.7.4/lib/ruby/gems/2.7.0/* \
-  && cp -r /tmp/cache/2.7/* /usr/local/rvm/rubies/ruby-2.7.4/lib/ruby/gems/2.7.0/ \
-  && rm -r /usr/local/rvm/rubies/ruby-3.0.2/lib/ruby/gems/3.0.0/* \
-  && cp -r /tmp/cache/3.0/* /usr/local/rvm/rubies/ruby-3.0.2/lib/ruby/gems/3.0.0/
+RUN  rm -r /usr/local/rvm/rubies/ruby-2.6.10/lib/ruby/gems/2.6.0/* \
+  && cp -r /tmp/cache/2.6/* /usr/local/rvm/rubies/ruby-2.6.10/lib/ruby/gems/2.6.0/ \
+  && rm -r /usr/local/rvm/rubies/ruby-2.7.6/lib/ruby/gems/2.7.0/* \
+  && cp -r /tmp/cache/2.7/* /usr/local/rvm/rubies/ruby-2.7.6/lib/ruby/gems/2.7.0/ \
+  && rm -r /usr/local/rvm/rubies/ruby-3.0.4/lib/ruby/gems/3.0.0/* \
+  && cp -r /tmp/cache/3.0/* /usr/local/rvm/rubies/ruby-3.0.4/lib/ruby/gems/3.0.0/

--- a/docker-rvm-supported/Makefile
+++ b/docker-rvm-supported/Makefile
@@ -7,9 +7,10 @@ all: build build-release push-latest push-tag
 push-release: push-tag push-latest
 
 build:
-	docker image build --squash -f Dockerfile -t kingdonb/rvm-supported:$(GIT_SHA_TAG) .
+	docker image build --push --squash -f Dockerfile -t kingdonb/rvm-supported:$(GIT_SHA_TAG) .
 
 build-release:
+	docker pull kingdonb/rvm-supported:$(GIT_SHA_TAG)
 	docker tag kingdonb/rvm-supported:$(GIT_SHA_TAG) kingdonb/rvm-supported:latest
 
 push-tag:


### PR DESCRIPTION
Some Makefile changes also to support the use of Docker with builders that do not export on build (need to use `--push`)